### PR TITLE
Move preloading to API controllers

### DIFF
--- a/lib/swapi/films.ex
+++ b/lib/swapi/films.ex
@@ -22,28 +22,26 @@ defmodule SWAPI.Films do
       [%Film{}, ...]
 
   """
-  def list_films do
-    Film
-    |> Repo.all()
-    |> preload_all()
-  end
+  def list_films, do: Repo.all(Film)
 
-  def list_films(params) do
-    with {:ok, {films, meta}} <- paginate(Film, params) do
-      {:ok, {preload_all(films), meta}}
-    end
+  def list_films(params), do: paginate(Film, params)
+
+  def search_films(terms) do
+    terms
+    |> Enum.reduce(Film, fn term, query ->
+      query
+      |> where([f], like(f.title, ^"%#{term}%"))
+    end)
+    |> Repo.all()
   end
 
   def search_films(terms, params) do
-    films =
-      Enum.reduce(terms, Film, fn term, query ->
-        query
-        |> where([f], like(f.title, ^"%#{term}%"))
-      end)
-
-    with {:ok, {films, meta}} <- paginate(films, params) do
-      {:ok, {preload_all(films), meta}}
-    end
+    terms
+    |> Enum.reduce(Film, fn term, query ->
+      query
+      |> where([f], like(f.title, ^"%#{term}%"))
+    end)
+    |> paginate(params)
   end
 
   @doc """
@@ -60,16 +58,12 @@ defmodule SWAPI.Films do
       ** (Ecto.NoResultsError)
 
   """
-  def get_film!(id) do
-    Film
-    |> Repo.get!(id)
-    |> preload_all()
-  end
+  def get_film!(id), do: Repo.get!(Film, id)
 
   def get_film(id) do
     case Repo.get(Film, id) do
       %Film{} = film ->
-        {:ok, preload_all(film)}
+        {:ok, film}
 
       _ ->
         {:error, :not_found}

--- a/lib/swapi/people.ex
+++ b/lib/swapi/people.ex
@@ -22,28 +22,26 @@ defmodule SWAPI.People do
       [%Person{}, ...]
 
   """
-  def list_people do
-    Person
-    |> Repo.all()
-    |> preload_all()
-  end
+  def list_people, do: Repo.all(Person)
 
-  def list_people(params) do
-    with {:ok, {people, meta}} <- paginate(Person, params) do
-      {:ok, {preload_all(people), meta}}
-    end
+  def list_people(params), do: paginate(Person, params)
+
+  def search_people(terms) do
+    terms
+    |> Enum.reduce(Person, fn term, query ->
+      query
+      |> where([p], like(p.name, ^"%#{term}%"))
+    end)
+    |> Repo.all()
   end
 
   def search_people(terms, params) do
-    people =
-      Enum.reduce(terms, Person, fn term, query ->
-        query
-        |> where([p], like(p.name, ^"%#{term}%"))
-      end)
-
-    with {:ok, {people, meta}} <- paginate(people, params) do
-      {:ok, {preload_all(people), meta}}
-    end
+    terms
+    |> Enum.reduce(Person, fn term, query ->
+      query
+      |> where([p], like(p.name, ^"%#{term}%"))
+    end)
+    |> paginate(params)
   end
 
   @doc """
@@ -60,16 +58,12 @@ defmodule SWAPI.People do
       ** (Ecto.NoResultsError)
 
   """
-  def get_person!(id) do
-    Person
-    |> Repo.get!(id)
-    |> preload_all()
-  end
+  def get_person!(id), do: Repo.get!(Person, id)
 
   def get_person(id) do
     case Repo.get(Person, id) do
       %Person{} = person ->
-        {:ok, preload_all(person)}
+        {:ok, person}
 
       _ ->
         {:error, :not_found}

--- a/lib/swapi/planets.ex
+++ b/lib/swapi/planets.ex
@@ -22,28 +22,26 @@ defmodule SWAPI.Planets do
       [%Planet{}, ...]
 
   """
-  def list_planets do
-    Planet
-    |> Repo.all()
-    |> preload_all()
-  end
+  def list_planets, do: Repo.all(Planet)
 
-  def list_planets(params) do
-    with {:ok, {planets, meta}} <- paginate(Planet, params) do
-      {:ok, {preload_all(planets), meta}}
-    end
+  def list_planets(params), do: paginate(Planet, params)
+
+  def search_planets(terms) do
+    terms
+    |> Enum.reduce(Planet, fn term, query ->
+      query
+      |> where([p], like(p.name, ^"%#{term}%"))
+    end)
+    |> Repo.all()
   end
 
   def search_planets(terms, params) do
-    planets =
-      Enum.reduce(terms, Planet, fn term, query ->
-        query
-        |> where([p], like(p.name, ^"%#{term}%"))
-      end)
-
-    with {:ok, {planets, meta}} <- paginate(planets, params) do
-      {:ok, {preload_all(planets), meta}}
-    end
+    terms
+    |> Enum.reduce(Planet, fn term, query ->
+      query
+      |> where([p], like(p.name, ^"%#{term}%"))
+    end)
+    |> paginate(params)
   end
 
   @doc """
@@ -60,16 +58,12 @@ defmodule SWAPI.Planets do
       ** (Ecto.NoResultsError)
 
   """
-  def get_planet!(id) do
-    Planet
-    |> Repo.get!(id)
-    |> preload_all()
-  end
+  def get_planet!(id), do: Repo.get!(Planet, id)
 
   def get_planet(id) do
     case Repo.get(Planet, id) do
       %Planet{} = planet ->
-        {:ok, preload_all(planet)}
+        {:ok, planet}
 
       _ ->
         {:error, :not_found}

--- a/lib/swapi/species.ex
+++ b/lib/swapi/species.ex
@@ -22,28 +22,26 @@ defmodule SWAPI.Species do
       [%Species{}, ...]
 
   """
-  def list_species do
-    Species
-    |> Repo.all()
-    |> preload_all()
-  end
+  def list_species, do: Repo.all(Species)
 
-  def list_species(params) do
-    with {:ok, {species, meta}} <- paginate(Species, params) do
-      {:ok, {preload_all(species), meta}}
-    end
+  def list_species(params), do: paginate(Species, params)
+
+  def search_species(terms) do
+    terms
+    |> Enum.reduce(Species, fn term, query ->
+      query
+      |> where([s], like(s.name, ^"%#{term}%"))
+    end)
+    |> Repo.all()
   end
 
   def search_species(terms, params) do
-    species =
-      Enum.reduce(terms, Species, fn term, query ->
-        query
-        |> where([s], like(s.name, ^"%#{term}%"))
-      end)
-
-    with {:ok, {species, meta}} <- paginate(species, params) do
-      {:ok, {preload_all(species), meta}}
-    end
+    terms
+    |> Enum.reduce(Species, fn term, query ->
+      query
+      |> where([s], like(s.name, ^"%#{term}%"))
+    end)
+    |> paginate(params)
   end
 
   @doc """
@@ -60,16 +58,12 @@ defmodule SWAPI.Species do
       ** (Ecto.NoResultsError)
 
   """
-  def get_species!(id) do
-    Species
-    |> Repo.get!(id)
-    |> preload_all()
-  end
+  def get_species!(id), do: Repo.get!(Species, id)
 
   def get_species(id) do
     case Repo.get(Species, id) do
       %Species{} = species ->
-        {:ok, preload_all(species)}
+        {:ok, species}
 
       _ ->
         {:error, :not_found}

--- a/lib/swapi_web/controllers/film_controller.ex
+++ b/lib/swapi_web/controllers/film_controller.ex
@@ -56,13 +56,13 @@ defmodule SWAPIWeb.FilmController do
     query = parse_search_query(query)
 
     with {:ok, {films, meta}} <- Films.search_films(query, params) do
-      render(conn, :index, films: films, meta: meta)
+      render(conn, :index, films: Films.preload_all(films), meta: meta)
     end
   end
 
   def index(conn, params) do
     with {:ok, {films, meta}} <- Films.list_films(params) do
-      render(conn, :index, films: films, meta: meta)
+      render(conn, :index, films: Films.preload_all(films), meta: meta)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SWAPIWeb.FilmController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, film} <- Films.get_film(id) do
-      render(conn, :show, film: film)
+      render(conn, :show, film: Films.preload_all(film))
     end
   end
 end

--- a/lib/swapi_web/controllers/person_controller.ex
+++ b/lib/swapi_web/controllers/person_controller.ex
@@ -56,13 +56,13 @@ defmodule SWAPIWeb.PersonController do
     query = parse_search_query(query)
 
     with {:ok, {people, meta}} <- People.search_people(query, params) do
-      render(conn, :index, people: people, meta: meta)
+      render(conn, :index, people: People.preload_all(people), meta: meta)
     end
   end
 
   def index(conn, params) do
     with {:ok, {people, meta}} <- People.list_people(params) do
-      render(conn, :index, people: people, meta: meta)
+      render(conn, :index, people: People.preload_all(people), meta: meta)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SWAPIWeb.PersonController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, person} <- People.get_person(id) do
-      render(conn, :show, person: person)
+      render(conn, :show, person: People.preload_all(person))
     end
   end
 end

--- a/lib/swapi_web/controllers/planet_controller.ex
+++ b/lib/swapi_web/controllers/planet_controller.ex
@@ -56,13 +56,13 @@ defmodule SWAPIWeb.PlanetController do
     query = parse_search_query(query)
 
     with {:ok, {planets, meta}} <- Planets.search_planets(query, params) do
-      render(conn, :index, planets: planets, meta: meta)
+      render(conn, :index, planets: Planets.preload_all(planets), meta: meta)
     end
   end
 
   def index(conn, params) do
     with {:ok, {planets, meta}} <- Planets.list_planets(params) do
-      render(conn, :index, planets: planets, meta: meta)
+      render(conn, :index, planets: Planets.preload_all(planets), meta: meta)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SWAPIWeb.PlanetController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, planet} <- Planets.get_planet(id) do
-      render(conn, :show, planet: planet)
+      render(conn, :show, planet: Planets.preload_all(planet))
     end
   end
 end

--- a/lib/swapi_web/controllers/species_controller.ex
+++ b/lib/swapi_web/controllers/species_controller.ex
@@ -56,13 +56,13 @@ defmodule SWAPIWeb.SpeciesController do
     query = parse_search_query(query)
 
     with {:ok, {species, meta}} <- Species.search_species(query, params) do
-      render(conn, :index, species: species, meta: meta)
+      render(conn, :index, species: Species.preload_all(species), meta: meta)
     end
   end
 
   def index(conn, params) do
     with {:ok, {species, meta}} <- Species.list_species(params) do
-      render(conn, :index, species: species, meta: meta)
+      render(conn, :index, species: Species.preload_all(species), meta: meta)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SWAPIWeb.SpeciesController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, species} <- Species.get_species(id) do
-      render(conn, :show, species: species)
+      render(conn, :show, species: Species.preload_all(species))
     end
   end
 end

--- a/lib/swapi_web/controllers/starship_controller.ex
+++ b/lib/swapi_web/controllers/starship_controller.ex
@@ -56,13 +56,13 @@ defmodule SWAPIWeb.StarshipController do
     query = parse_search_query(query)
 
     with {:ok, {starships, meta}} <- Starships.search_starships(query, params) do
-      render(conn, :index, starships: starships, meta: meta)
+      render(conn, :index, starships: Starships.preload_all(starships), meta: meta)
     end
   end
 
   def index(conn, params) do
     with {:ok, {starships, meta}} <- Starships.list_starships(params) do
-      render(conn, :index, starships: starships, meta: meta)
+      render(conn, :index, starships: Starships.preload_all(starships), meta: meta)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SWAPIWeb.StarshipController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, starship} <- Starships.get_starship(id) do
-      render(conn, :show, starship: starship)
+      render(conn, :show, starship: Starships.preload_all(starship))
     end
   end
 end

--- a/lib/swapi_web/controllers/vehicle_controller.ex
+++ b/lib/swapi_web/controllers/vehicle_controller.ex
@@ -56,13 +56,13 @@ defmodule SWAPIWeb.VehicleController do
     query = parse_search_query(query)
 
     with {:ok, {vehicles, meta}} <- Vehicles.search_vehicles(query, params) do
-      render(conn, :index, vehicles: vehicles, meta: meta)
+      render(conn, :index, vehicles: Vehicles.preload_all(vehicles), meta: meta)
     end
   end
 
   def index(conn, params) do
     with {:ok, {vehicles, meta}} <- Vehicles.list_vehicles(params) do
-      render(conn, :index, vehicles: vehicles, meta: meta)
+      render(conn, :index, vehicles: Vehicles.preload_all(vehicles), meta: meta)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SWAPIWeb.VehicleController do
 
   def show(conn, %{"id" => id}) do
     with {:ok, vehicle} <- Vehicles.get_vehicle(id) do
-      render(conn, :show, vehicle: vehicle)
+      render(conn, :show, vehicle: Vehicles.preload_all(vehicle))
     end
   end
 end

--- a/test/swapi/people_test.exs
+++ b/test/swapi/people_test.exs
@@ -21,12 +21,13 @@ defmodule SWAPI.PeopleTest do
 
     test "list_people/0 returns all people" do
       person = person_fixture()
-      assert People.list_people() == [person]
+      assert [^person] = People.list_people() |> Enum.map(&People.preload_all/1)
     end
 
     test "list_people/1 returns all people" do
       person = person_fixture()
-      assert {:ok, {[^person], _}} = People.list_people(%{})
+      assert {:ok, {people, _}} = People.list_people(%{})
+      assert [^person] = Enum.map(people, &People.preload_all/1)
     end
 
     test "search_people/1 returns only matching people" do
@@ -34,21 +35,23 @@ defmodule SWAPI.PeopleTest do
       person_fixture(%{name: "foo bar"})
       person_fixture(%{name: "foo"})
 
-      assert {:ok, {[^person], _}} = People.search_people(["foo", "bar", "baz"], %{})
+      assert {:ok, {people, _}} = People.search_people(["foo", "bar", "baz"], %{})
+      assert [^person] = Enum.map(people, &People.preload_all/1)
     end
 
     test "get_person!/1 returns the person with given id" do
       person = person_fixture()
-      assert People.get_person!(person.id) == person
+      assert ^person = People.get_person!(person.id) |> People.preload_all()
     end
 
     test "get_person/1 returns the person with given id" do
       person = person_fixture()
-      assert People.get_person(person.id) == {:ok, person}
+      assert {:ok, returned_person} = People.get_person(person.id)
+      assert ^person = People.preload_all(returned_person)
     end
 
     test "get_person/1 returns error when given id does not exist" do
-      assert People.get_person(42) == {:error, :not_found}
+      assert {:error, :not_found} = People.get_person(42)
     end
 
     test "create_person/1 with valid data creates a person" do
@@ -63,15 +66,17 @@ defmodule SWAPI.PeopleTest do
         skin_color: "some skin_color"
       }
 
-      assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
-      assert person.name == "some name"
-      assert person.birth_year == "some birth_year"
-      assert person.eye_color == "some eye_color"
-      assert person.gender == "some gender"
-      assert person.hair_color == "some hair_color"
-      assert person.height == "some height"
-      assert person.mass == "some mass"
-      assert person.skin_color == "some skin_color"
+      assert {:ok,
+              %Person{
+                name: "some name",
+                birth_year: "some birth_year",
+                eye_color: "some eye_color",
+                gender: "some gender",
+                hair_color: "some hair_color",
+                height: "some height",
+                mass: "some mass",
+                skin_color: "some skin_color"
+              }} = People.create_person(valid_attrs)
     end
 
     test "create_person/1 with invalid data returns error changeset" do
@@ -92,21 +97,23 @@ defmodule SWAPI.PeopleTest do
         skin_color: "some updated skin_color"
       }
 
-      assert {:ok, %Person{} = person} = People.update_person(person, update_attrs)
-      assert person.name == "some updated name"
-      assert person.birth_year == "some updated birth_year"
-      assert person.eye_color == "some updated eye_color"
-      assert person.gender == "some updated gender"
-      assert person.hair_color == "some updated hair_color"
-      assert person.height == "some updated height"
-      assert person.mass == "some updated mass"
-      assert person.skin_color == "some updated skin_color"
+      assert {:ok,
+              %Person{
+                name: "some updated name",
+                birth_year: "some updated birth_year",
+                eye_color: "some updated eye_color",
+                gender: "some updated gender",
+                hair_color: "some updated hair_color",
+                height: "some updated height",
+                mass: "some updated mass",
+                skin_color: "some updated skin_color"
+              }} = People.update_person(person, update_attrs)
     end
 
     test "update_person/2 with invalid data returns error changeset" do
       person = person_fixture()
       assert {:error, %Ecto.Changeset{}} = People.update_person(person, @invalid_attrs)
-      assert person == People.get_person!(person.id)
+      assert ^person = People.get_person!(person.id) |> People.preload_all()
     end
 
     test "delete_person/1 deletes the person" do

--- a/test/swapi/planets_test.exs
+++ b/test/swapi/planets_test.exs
@@ -22,12 +22,13 @@ defmodule SWAPI.PlanetsTest do
 
     test "list_planets/0 returns all planets" do
       planet = planet_fixture()
-      assert Planets.list_planets() == [planet]
+      assert [^planet] = Planets.list_planets() |> Enum.map(&Planets.preload_all/1)
     end
 
     test "list_planets/1 returns all planets" do
       planet = planet_fixture()
-      assert {:ok, {[^planet], _}} = Planets.list_planets(%{})
+      assert {:ok, {planets, _}} = Planets.list_planets(%{})
+      assert [^planet] = Enum.map(planets, &Planets.preload_all/1)
     end
 
     test "search_planets/1 returns only matching planets" do
@@ -35,21 +36,23 @@ defmodule SWAPI.PlanetsTest do
       planet_fixture(%{name: "foo bar"})
       planet_fixture(%{name: "foo"})
 
-      assert {:ok, {[^planet], _}} = Planets.search_planets(["foo", "bar", "baz"], %{})
+      assert {:ok, {planets, _}} = Planets.search_planets(["foo", "bar", "baz"], %{})
+      assert [^planet] = Enum.map(planets, &Planets.preload_all/1)
     end
 
     test "get_planet!/1 returns the planet with given id" do
       planet = planet_fixture()
-      assert Planets.get_planet!(planet.id) == planet
+      assert ^planet = Planets.get_planet!(planet.id) |> Planets.preload_all()
     end
 
     test "get_planet/1 returns the planet with given id" do
       planet = planet_fixture()
-      assert Planets.get_planet(planet.id) == {:ok, planet}
+      assert {:ok, returned_planet} = Planets.get_planet(planet.id)
+      assert ^planet = Planets.preload_all(returned_planet)
     end
 
     test "get_planet/1 returns error when given id does not exist" do
-      assert Planets.get_planet(42) == {:error, :not_found}
+      assert {:error, :not_found} = Planets.get_planet(42)
     end
 
     test "create_planet/1 with valid data creates a planet" do
@@ -65,16 +68,18 @@ defmodule SWAPI.PlanetsTest do
         surface_water: "some surface_water"
       }
 
-      assert {:ok, %Planet{} = planet} = Planets.create_planet(valid_attrs)
-      assert planet.name == "some name"
-      assert planet.diameter == "some diameter"
-      assert planet.rotation_period == "some rotation_period"
-      assert planet.orbital_period == "some orbital_period"
-      assert planet.gravity == "some gravity"
-      assert planet.population == "some population"
-      assert planet.climate == "some climate"
-      assert planet.terrain == "some terrain"
-      assert planet.surface_water == "some surface_water"
+      assert {:ok,
+              %Planet{
+                name: "some name",
+                diameter: "some diameter",
+                rotation_period: "some rotation_period",
+                orbital_period: "some orbital_period",
+                gravity: "some gravity",
+                population: "some population",
+                climate: "some climate",
+                terrain: "some terrain",
+                surface_water: "some surface_water"
+              }} = Planets.create_planet(valid_attrs)
     end
 
     test "create_planet/1 with invalid data returns error changeset" do
@@ -96,22 +101,24 @@ defmodule SWAPI.PlanetsTest do
         surface_water: "some updated surface_water"
       }
 
-      assert {:ok, %Planet{} = planet} = Planets.update_planet(planet, update_attrs)
-      assert planet.name == "some updated name"
-      assert planet.diameter == "some updated diameter"
-      assert planet.rotation_period == "some updated rotation_period"
-      assert planet.orbital_period == "some updated orbital_period"
-      assert planet.gravity == "some updated gravity"
-      assert planet.population == "some updated population"
-      assert planet.climate == "some updated climate"
-      assert planet.terrain == "some updated terrain"
-      assert planet.surface_water == "some updated surface_water"
+      assert {:ok,
+              %Planet{
+                name: "some updated name",
+                diameter: "some updated diameter",
+                rotation_period: "some updated rotation_period",
+                orbital_period: "some updated orbital_period",
+                gravity: "some updated gravity",
+                population: "some updated population",
+                climate: "some updated climate",
+                terrain: "some updated terrain",
+                surface_water: "some updated surface_water"
+              }} = Planets.update_planet(planet, update_attrs)
     end
 
     test "update_planet/2 with invalid data returns error changeset" do
       planet = planet_fixture()
       assert {:error, %Ecto.Changeset{}} = Planets.update_planet(planet, @invalid_attrs)
-      assert planet == Planets.get_planet!(planet.id)
+      assert ^planet = Planets.get_planet!(planet.id) |> Planets.preload_all()
     end
 
     test "delete_planet/1 deletes the planet" do

--- a/test/swapi/species_test.exs
+++ b/test/swapi/species_test.exs
@@ -22,12 +22,13 @@ defmodule SWAPI.SpeciesTest do
 
     test "list_species/0 returns all species" do
       species = species_fixture()
-      assert Species.list_species() == [species]
+      assert [^species] = Species.list_species() |> Enum.map(&Species.preload_all/1)
     end
 
     test "list_species/1 returns all species" do
       species = species_fixture()
-      assert {:ok, {[^species], _}} = Species.list_species(%{})
+      assert {:ok, {species_list, _}} = Species.list_species(%{})
+      assert [^species] = species_list |> Enum.map(&Species.preload_all/1)
     end
 
     test "search_species/1 returns only matching species" do
@@ -35,21 +36,23 @@ defmodule SWAPI.SpeciesTest do
       species_fixture(%{name: "foo bar"})
       species_fixture(%{name: "foo"})
 
-      assert {:ok, {[^species], _}} = Species.search_species(["foo", "bar", "baz"], %{})
+      assert {:ok, {species_list, _}} = Species.search_species(["foo", "bar", "baz"], %{})
+      assert [^species] = species_list |> Enum.map(&Species.preload_all/1)
     end
 
     test "get_species!/1 returns the species with given id" do
       species = species_fixture()
-      assert Species.get_species!(species.id) == species
+      assert ^species = Species.get_species!(species.id) |> Species.preload_all()
     end
 
     test "get_species/1 returns the species with given id" do
       species = species_fixture()
-      assert Species.get_species(species.id) == {:ok, species}
+      assert {:ok, returned_species} = Species.get_species(species.id)
+      assert ^species = Species.preload_all(returned_species)
     end
 
     test "get_species/1 returns error when given id does not exist" do
-      assert Species.get_species(42) == {:error, :not_found}
+      assert {:error, :not_found} = Species.get_species(42)
     end
 
     test "create_species/1 with valid data creates a species" do
@@ -65,16 +68,18 @@ defmodule SWAPI.SpeciesTest do
         language: "some language"
       }
 
-      assert {:ok, %SpeciesSchema{} = species} = Species.create_species(valid_attrs)
-      assert species.name == "some name"
-      assert species.classification == "some classification"
-      assert species.designation == "some designation"
-      assert species.average_height == "some average_height"
-      assert species.average_lifespan == "some average_lifespan"
-      assert species.eye_colors == "some eye_colors"
-      assert species.hair_colors == "some hair_colors"
-      assert species.skin_colors == "some skin_colors"
-      assert species.language == "some language"
+      assert {:ok,
+              %SpeciesSchema{
+                name: "some name",
+                classification: "some classification",
+                designation: "some designation",
+                average_height: "some average_height",
+                average_lifespan: "some average_lifespan",
+                eye_colors: "some eye_colors",
+                hair_colors: "some hair_colors",
+                skin_colors: "some skin_colors",
+                language: "some language"
+              }} = Species.create_species(valid_attrs)
     end
 
     test "create_species/1 with invalid data returns error changeset" do
@@ -96,22 +101,24 @@ defmodule SWAPI.SpeciesTest do
         language: "some updated language"
       }
 
-      assert {:ok, %SpeciesSchema{} = species} = Species.update_species(species, update_attrs)
-      assert species.name == "some updated name"
-      assert species.classification == "some updated classification"
-      assert species.designation == "some updated designation"
-      assert species.average_height == "some updated average_height"
-      assert species.average_lifespan == "some updated average_lifespan"
-      assert species.eye_colors == "some updated eye_colors"
-      assert species.hair_colors == "some updated hair_colors"
-      assert species.skin_colors == "some updated skin_colors"
-      assert species.language == "some updated language"
+      assert {:ok,
+              %SpeciesSchema{
+                name: "some updated name",
+                classification: "some updated classification",
+                designation: "some updated designation",
+                average_height: "some updated average_height",
+                average_lifespan: "some updated average_lifespan",
+                eye_colors: "some updated eye_colors",
+                hair_colors: "some updated hair_colors",
+                skin_colors: "some updated skin_colors",
+                language: "some updated language"
+              }} = Species.update_species(species, update_attrs)
     end
 
     test "update_species/2 with invalid data returns error changeset" do
       species = species_fixture()
       assert {:error, %Ecto.Changeset{}} = Species.update_species(species, @invalid_attrs)
-      assert species == Species.get_species!(species.id)
+      assert ^species = Species.get_species!(species.id) |> Species.preload_all()
     end
 
     test "delete_species/1 deletes the species" do

--- a/test/swapi/vehicles_test.exs
+++ b/test/swapi/vehicles_test.exs
@@ -26,12 +26,13 @@ defmodule SWAPI.VehiclesTest do
 
     test "list_vehicles/0 returns all vehicles" do
       vehicle = vehicle_fixture()
-      assert Vehicles.list_vehicles() == [vehicle]
+      assert [^vehicle] = Vehicles.list_vehicles() |> Enum.map(&Vehicles.preload_all/1)
     end
 
     test "list_vehicles/1 returns all vehicles" do
       vehicle = vehicle_fixture()
-      assert {:ok, {[^vehicle], _}} = Vehicles.list_vehicles(%{})
+      assert {:ok, {vehicles, _}} = Vehicles.list_vehicles(%{})
+      assert [^vehicle] = Enum.map(vehicles, &Vehicles.preload_all/1)
     end
 
     test "search_vehicles/1 returns only matching vehicles" do
@@ -44,6 +45,8 @@ defmodule SWAPI.VehiclesTest do
       vehicle_fixture(%{transport: %{model: "bar"}})
 
       {:ok, {vehicles, _}} = Vehicles.search_vehicles(["foo", "bar", "baz"], %{})
+      vehicles = Enum.map(vehicles, &Vehicles.preload_all/1)
+
       assert length(vehicles) == 2
       assert vehicle1 in vehicles
       assert vehicle2 in vehicles
@@ -51,16 +54,17 @@ defmodule SWAPI.VehiclesTest do
 
     test "get_vehicle!/1 returns the vehicle with given id" do
       vehicle = vehicle_fixture()
-      assert Vehicles.get_vehicle!(vehicle.id) == vehicle
+      assert ^vehicle = Vehicles.get_vehicle!(vehicle.id) |> Vehicles.preload_all()
     end
 
     test "get_vehicle/1 returns the vehicle with given id" do
       vehicle = vehicle_fixture()
-      assert Vehicles.get_vehicle(vehicle.id) == {:ok, vehicle}
+      assert {:ok, returned_vehicle} = Vehicles.get_vehicle(vehicle.id)
+      assert ^vehicle = Vehicles.preload_all(returned_vehicle)
     end
 
     test "get_vehicle/1 returns error when given id does not exist" do
-      assert Vehicles.get_vehicle(42) == {:error, :not_found}
+      assert {:error, :not_found} = Vehicles.get_vehicle(42)
     end
 
     test "create_vehicle/1 with valid data creates a vehicle" do
@@ -81,17 +85,22 @@ defmodule SWAPI.VehiclesTest do
       }
 
       assert {:ok, %Vehicle{} = vehicle} = Vehicles.create_vehicle(valid_attrs)
-      assert vehicle.transport.name == "some name"
-      assert vehicle.transport.model == "some model"
-      assert vehicle.transport.manufacturer == "some manufacturer"
-      assert vehicle.transport.length == "some length"
-      assert vehicle.transport.cost_in_credits == "some cost_in_credits"
-      assert vehicle.transport.crew == "some crew"
-      assert vehicle.transport.passengers == "some passengers"
-      assert vehicle.transport.max_atmosphering_speed == "some max_atmosphering_speed"
-      assert vehicle.transport.cargo_capacity == "some cargo_capacity"
-      assert vehicle.transport.consumables == "some consumables"
-      assert vehicle.vehicle_class == "some vehicle_class"
+
+      assert %Vehicle{
+               transport: %{
+                 name: "some name",
+                 model: "some model",
+                 manufacturer: "some manufacturer",
+                 length: "some length",
+                 cost_in_credits: "some cost_in_credits",
+                 crew: "some crew",
+                 passengers: "some passengers",
+                 max_atmosphering_speed: "some max_atmosphering_speed",
+                 cargo_capacity: "some cargo_capacity",
+                 consumables: "some consumables"
+               },
+               vehicle_class: "some vehicle_class"
+             } = Vehicles.preload_all(vehicle)
     end
 
     test "create_vehicle/1 with invalid data returns error changeset" do
@@ -118,23 +127,28 @@ defmodule SWAPI.VehiclesTest do
       }
 
       assert {:ok, %Vehicle{} = vehicle} = Vehicles.update_vehicle(vehicle, update_attrs)
-      assert vehicle.transport.name == "some updated name"
-      assert vehicle.transport.model == "some updated model"
-      assert vehicle.transport.manufacturer == "some updated manufacturer"
-      assert vehicle.transport.length == "some updated length"
-      assert vehicle.transport.cost_in_credits == "some updated cost_in_credits"
-      assert vehicle.transport.crew == "some updated crew"
-      assert vehicle.transport.passengers == "some updated passengers"
-      assert vehicle.transport.max_atmosphering_speed == "some updated max_atmosphering_speed"
-      assert vehicle.transport.cargo_capacity == "some updated cargo_capacity"
-      assert vehicle.transport.consumables == "some updated consumables"
-      assert vehicle.vehicle_class == "some updated vehicle_class"
+
+      assert %Vehicle{
+               transport: %{
+                 name: "some updated name",
+                 model: "some updated model",
+                 manufacturer: "some updated manufacturer",
+                 length: "some updated length",
+                 cost_in_credits: "some updated cost_in_credits",
+                 crew: "some updated crew",
+                 passengers: "some updated passengers",
+                 max_atmosphering_speed: "some updated max_atmosphering_speed",
+                 cargo_capacity: "some updated cargo_capacity",
+                 consumables: "some updated consumables"
+               },
+               vehicle_class: "some updated vehicle_class"
+             } = Vehicles.preload_all(vehicle)
     end
 
     test "update_vehicle/2 with invalid data returns error changeset" do
       vehicle = vehicle_fixture()
       assert {:error, %Ecto.Changeset{}} = Vehicles.update_vehicle(vehicle, @invalid_attrs)
-      assert vehicle == Vehicles.get_vehicle!(vehicle.id)
+      assert ^vehicle = Vehicles.get_vehicle!(vehicle.id) |> Vehicles.preload_all()
     end
 
     test "delete_vehicle/1 deletes the vehicle" do


### PR DESCRIPTION
Moving preloading to REST API controllers in preparation for GraphQL, which handles this via dataloader